### PR TITLE
Clearer distinction of examples and tests

### DIFF
--- a/examples/butane_thermo.yaml
+++ b/examples/butane_thermo.yaml
@@ -1,9 +1,5 @@
---- # test setup
-description: How to represent thermochemistry data using Butane as an example
-# schema_part: schema.Schema  - not needed for this example (schema.Schema is
-#                               the default); used to test against a subschema
-failures: []   # fully valid file
---- # actual example
+# This file shows how the conformers of butane can be described in RMMD.
+# It also shows how to link thermochemistry data to the conformers.
 schema_version: 0.1.0b0
 license: MIT
 species:

--- a/examples/minimal.yaml
+++ b/examples/minimal.yaml
@@ -1,7 +1,5 @@
---- # test setup
-description: This is a mimial example of a valid file
-# schema_part: schema.Schema  - not needed for this example (schema.Schema is
-#                               the default); used to test against a subschema
---- # actual example
+# This is the minimum content of an RMMD file to be valid.
+# It contains the RMMD schema version and a license for the data contained in
+# the file.
 schema_version: 0.1.0b0
 license: MIT

--- a/src/rmmd/metadata.py
+++ b/src/rmmd/metadata.py
@@ -58,7 +58,7 @@ def check_if_consistent_doi_or_handle(url: AnyUrl) -> AnyUrl:
     elif url.host == "hdl.handle.net" and url.scheme != "https":
         raise ValueError(
             "HandleNet identifiers should be provided as full URLs "
-            "starting with https://hdl.handle.net/... "
+            "starting with https://hdl.handle.net/..."
         )
 
     return url

--- a/src/rmmd/test.py
+++ b/src/rmmd/test.py
@@ -1,0 +1,73 @@
+"""Module containing helper functions for testing."""
+
+
+import re
+from typing import Any
+from pydantic import BaseModel, ValidationError
+import pytest
+
+def _err_loc_str(loc: tuple[str | int, ...]) -> str:
+    """Convert a location tuple to a string"""
+    loc_str = loc[0] if isinstance(loc[0], str) else f"[{loc[0]}]"
+
+    for loc_entry in loc[1:]:
+        if isinstance(loc_entry, int):
+            loc_str += f"[{loc_entry}]"
+        else:
+            loc_str += f".{loc_entry}"
+
+    return loc_str
+
+def assert_model_validation_errors(
+        model: type[BaseModel],
+        data: Any,
+        expected_errors: list[tuple[tuple[str | int, ...], str]]):
+    """Assert that the model validation raises the expected errors.
+
+    :param model: The Pydantic model to validate against.
+    :param data: The data to validate.
+    :param expected_errors: A list of tuples where each tuple contains a
+                            location (as a tuple of strings or integers) and a
+                            regex pattern for the expected error message.
+    """
+    msg = ""
+    # encountered ids will be removed from this set:
+    unencountered_expected_errids = {i for i in range(len(expected_errors))}
+
+    try:
+        model.model_validate(data)
+    except ValidationError as val_err:
+        actual_errors = [
+            (err["loc"], err["msg"]) for err in val_err.errors()
+        ]
+        # ids of actual errors that were not expected
+        unexpected_actual_errids = {i for i in range(len(actual_errors))}
+
+        for i_expected, (loc, msg_pattern) in enumerate(expected_errors):
+            for i_actual, actual_err in enumerate(actual_errors):
+                if loc == actual_err[0]:
+                    if re.match(msg_pattern, actual_err[1]):
+                        # expected error was encountered
+                        unencountered_expected_errids.discard(i_expected)
+                        unexpected_actual_errids.discard(i_actual)
+
+        if unexpected_actual_errids:
+            msg += "Unexpected error(s):\n"
+            for i in unexpected_actual_errids:
+                loc, errmsg = actual_errors[i]
+                if loc:
+                    msg += f"    {_err_loc_str(loc)}: {errmsg}\n"
+                else:
+                    msg += f"    {errmsg}\n"
+
+    if unencountered_expected_errids:
+        msg += "Expected error(s) missing:\n"
+        for i in unencountered_expected_errids:
+            loc, errpattern = expected_errors[i]
+            if loc:
+                msg += f"    {_err_loc_str(loc)}: {errpattern}\n"
+            else:
+                msg += f"    {errpattern}\n"
+
+    if msg:
+        pytest.fail(msg)

--- a/src/rmmd/test.py
+++ b/src/rmmd/test.py
@@ -1,11 +1,11 @@
 """Module containing helper functions for testing."""
 
-
 import re
 from typing import Any, Self
 from pydantic import BaseModel, ValidationError, model_validator
 from pydantic_core import ErrorDetails
 import pytest
+
 
 def _err_loc_str(loc: tuple[str | int, ...]) -> str:
     """Convert a location tuple to a string"""
@@ -18,6 +18,7 @@ def _err_loc_str(loc: tuple[str | int, ...]) -> str:
             loc_str += f".{loc_entry}"
 
     return loc_str
+
 
 class ExpectedError(BaseModel):
     """Expected validation error for a model validation test."""
@@ -33,7 +34,7 @@ class ExpectedError(BaseModel):
 
     Either msg or msg_pattern must be provided."""
 
-    @model_validator(mode='after')
+    @model_validator(mode="after")
     def check_either_msg_or_pattern_existing(self) -> Self:
         """Ensure that either msg or msg_pattern is provided."""
         if self.msg is None != self.msg_pattern is None:
@@ -44,9 +45,9 @@ class ExpectedError(BaseModel):
 
     class Config:
         """Pydantic configuration."""
+
         extra = "forbid"  # forbid additional fields
         frozen = True  # make instances immutable
-
 
     def is_equivalent_to_error(self, error: ErrorDetails) -> bool:
         """Check if this expected error is equivalent to the given error."""
@@ -61,10 +62,10 @@ class ExpectedError(BaseModel):
 
         return True
 
+
 def assert_model_validation_errors(
-        model: type[BaseModel],
-        data: Any,
-        expected_errors: list[ExpectedError]):
+    model: type[BaseModel], data: Any, expected_errors: list[ExpectedError]
+):
     """Assert that the model validation raises the expected errors.
 
     :param model: The Pydantic model to validate against.

--- a/tests/rmmd/test_metadata_direct_reference.yaml
+++ b/tests/rmmd/test_metadata_direct_reference.yaml
@@ -4,17 +4,25 @@ schema_part: metadata._DirectReferenceTest # this special model allows defining
                 # a list of direct references so we include multiple test cases
                 # in this one file
 failures:
-  - ['0.HttpUrlReference',  # since we use a discriminated union, the model is
+  - - [0, 'HttpUrlReference']  # since we use a discriminated union, the model is
                             # part of the location
-    'Value error, HandleNet identifiers should be provided as full URLs.*']
-  - ['1.HandleNet', 'String should match pattern .*handle\\\.net.*']
-  - ['2.HttpUrlReference', 'Value error, DOIs should be provided as full URLs starting with https']
-  - ['3.HttpUrlReference', 'Value error, DOIs should follow the format https:\/\/doi\.org\/10\.xxxx\/\.\.\. ']
-  - ['4.Doi', 'String should match pattern.*']
-  - ['7', 'Could not determine the type of direct reference.*']
-  - ['9', 'Could not determine the type of direct reference.*']
-  - ['10', 'Could not determine the type of direct reference.*'] # absolute paths not allowed
-  - ['11.HttpUrlReference', 'Value error, HandleNet identifiers should be provided as full URLs starting with https.*'] # absolute paths not allowed
+    - 'Value error, HandleNet identifiers should be provided as full URLs.*'
+  - - [1, 'HandleNet']
+    - 'String should match pattern .*handle\\\.net.*'
+  - - [2, 'HttpUrlReference']
+    - 'Value error, DOIs should be provided as full URLs starting with https'
+  - - [3, 'HttpUrlReference']
+    - 'Value error, DOIs should follow the format https://doi.org/10.xxxx/.*'
+  - - [4, 'Doi']
+    - 'String should match pattern.*'
+  - - [7]
+    - 'Could not determine the type of direct reference.*'
+  - - [9]
+    - 'Could not determine the type of direct reference.*'
+  - - [10]
+    - 'Could not determine the type of direct reference.*'  # absolute paths not allowed
+  - - [11, 'HttpUrlReference']
+    - 'Value error, HandleNet identifiers should be provided as full URLs starting with https.*' # absolute paths not allowed
 --- # actual example
 - "http://hdl.handle.net/10.1234/abcd" # invalid: http instead of https
 - "https://hdl.handle.net/10.1234/abcd" # invalid DOI with handle.net resolver

--- a/tests/rmmd/test_metadata_direct_reference.yaml
+++ b/tests/rmmd/test_metadata_direct_reference.yaml
@@ -4,25 +4,25 @@ schema_part: metadata._DirectReferenceTest # this special model allows defining
                 # a list of direct references so we include multiple test cases
                 # in this one file
 failures:
-  - - [0, 'HttpUrlReference']  # since we use a discriminated union, the model is
+  - loc: [0, 'HttpUrlReference']  # since we use a discriminated union, the model is
                             # part of the location
-    - 'Value error, HandleNet identifiers should be provided as full URLs.*'
-  - - [1, 'HandleNet']
-    - 'String should match pattern .*handle\\\.net.*'
-  - - [2, 'HttpUrlReference']
-    - 'Value error, DOIs should be provided as full URLs starting with https'
-  - - [3, 'HttpUrlReference']
-    - 'Value error, DOIs should follow the format https://doi.org/10.xxxx/.*'
-  - - [4, 'Doi']
-    - 'String should match pattern.*'
-  - - [7]
-    - 'Could not determine the type of direct reference.*'
-  - - [9]
-    - 'Could not determine the type of direct reference.*'
-  - - [10]
-    - 'Could not determine the type of direct reference.*'  # absolute paths not allowed
-  - - [11, 'HttpUrlReference']
-    - 'Value error, HandleNet identifiers should be provided as full URLs starting with https.*' # absolute paths not allowed
+    msg_pattern: 'Value error, HandleNet identifiers should be provided as full URLs.*'
+  - loc: [1, 'HandleNet']
+    msg_pattern: 'String should match pattern .*handle\\\.net.*'
+  - loc: [2, 'HttpUrlReference']
+    msg: 'Value error, DOIs should be provided as full URLs starting with https'
+  - loc: [3, 'HttpUrlReference']
+    msg_pattern: 'Value error, DOIs should follow the format https://doi.org/10.xxxx/.*'
+  - loc: [4, 'Doi']
+    msg: 'String should match pattern ''^https:\/\/doi\.org\/10\.\d{4,}/.*'''
+  - loc: [7]
+    msg: 'Could not determine the type of direct reference. Valid direct references include DOIs, HandleNet identifiers, HTTP URLs, or relative file paths.'
+  - loc: [9]
+    msg_pattern: 'Could not determine the type of direct reference.*'
+  - loc: [10]
+    msg_pattern: 'Could not determine the type of direct reference.*'  # absolute paths not allowed
+  - loc: [11, 'HttpUrlReference']
+    msg: 'Value error, HandleNet identifiers should be provided as full URLs starting with https://hdl.handle.net/...' # absolute paths not allowed
 --- # actual example
 - "http://hdl.handle.net/10.1234/abcd" # invalid: http instead of https
 - "https://hdl.handle.net/10.1234/abcd" # invalid DOI with handle.net resolver

--- a/tests/rmmd/test_pes_geometry.yaml
+++ b/tests/rmmd/test_pes_geometry.yaml
@@ -2,11 +2,17 @@
 description: Test geometry model.
 schema_part: pes._GeometryTest # test only the geometry model
 failures:
-  - [geometry_list.1, "Value error, Number of atoms and coordinates must match"]
-  - [geometry_list.2, "Value error, Each atom must have 3 cartesian coordinates"]
-  - [geometry_list.3, "Value error, Each atom must have 3 cartesian coordinates"]
-  - [geometry_list.4.atoms.1, "Input should be 'H', 'He', .*"]
-  - [geometries_list.1, "Value error, Number of atoms and coordinates must match"]
+  - - ['geometry_list', 1]
+    - 'Value error, Number of atoms and coordinates must match'
+  - - ['geometry_list', 2]
+    - 'Value error, Each atom must have 3 cartesian coordinates'
+  - - ['geometry_list', 3]
+    - 'Value error, Each atom must have 3 cartesian coordinates'
+  - - ['geometry_list', 4, 'atoms', 1]
+    - 'Input should be ''H'', ''He'', .*'
+  - - ['geometries_list', 1]
+    - 'Value error, Number of atoms and coordinates must match'
+
 --- # actual example
 geometry_list:
   - # valid geometry (caffeine)

--- a/tests/rmmd/test_pes_geometry.yaml
+++ b/tests/rmmd/test_pes_geometry.yaml
@@ -2,17 +2,16 @@
 description: Test geometry model.
 schema_part: pes._GeometryTest # test only the geometry model
 failures:
-  - - ['geometry_list', 1]
-    - 'Value error, Number of atoms and coordinates must match'
-  - - ['geometry_list', 2]
-    - 'Value error, Each atom must have 3 cartesian coordinates'
-  - - ['geometry_list', 3]
-    - 'Value error, Each atom must have 3 cartesian coordinates'
-  - - ['geometry_list', 4, 'atoms', 1]
-    - 'Input should be ''H'', ''He'', .*'
-  - - ['geometries_list', 1]
-    - 'Value error, Number of atoms and coordinates must match'
-
+  - loc: ['geometry_list', 1]
+    msg: 'Value error, Number of atoms and coordinates must match'
+  - loc: ['geometry_list', 2]
+    msg: 'Value error, Each atom must have 3 cartesian coordinates'
+  - loc: ['geometry_list', 3]
+    msg: 'Value error, Each atom must have 3 cartesian coordinates'
+  - loc: ['geometry_list', 4, 'atoms', 1]
+    msg_pattern: 'Input should be ''H'', ''He'', .*'
+  - loc: ['geometries_list', 1]
+    msg: 'Value error, Number of atoms and coordinates must match'
 --- # actual example
 geometry_list:
   - # valid geometry (caffeine)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,28 +1,12 @@
 from pathlib import Path
-import re
 
+from rmmd import schema
+from rmmd.test import assert_model_validation_errors
 import yaml
 import pytest
-from pydantic import BaseModel, Field, ValidationError
 
-import importlib
-
-
-HERE = Path(__file__).parent.resolve()
-EXAMPLES_DIR = HERE.parent / "examples"
-
-
-class ExampleMetadata(BaseModel):
-    """specification of the metadata block of the examples"""
-
-    model_config = {"extra": "forbid"}
-
-    failures: list[tuple[str, str]] = Field(default_factory=list)
-    """each item is an expected validation error, given as tuple of a string representing the location of the error and a message."""
-    description: str | None = None
-    schema_part: str = "schema.Schema"  # complete schema by default
-    relative_path: Path
-    """path to the example file relative to the examples directory"""
+_HERE = Path(__file__).parent.resolve()
+_EXAMPLES_DIR = _HERE.parent / "examples"
 
 
 ###############################################################################
@@ -30,9 +14,9 @@ class ExampleMetadata(BaseModel):
 ###############################################################################
 
 
-def _list_all_example_files():
+def _list_all_example_files() -> list[Path]:
     example_files = []
-    for path in EXAMPLES_DIR.rglob("*"):
+    for path in _EXAMPLES_DIR.rglob("*"):
         if path.is_file():
             example_files.append(path)
     return example_files
@@ -46,21 +30,6 @@ _examples = {  # will be filled later
 _errors_during_setup: list[tuple[str, str]] = []
 """list of files that could not be loaded"""
 
-
-def _import_model(name: str) -> type[BaseModel]:
-    """Get a model by its name"""
-    parts = name.split(".")
-    class_name = parts[-1]
-    module_name = ".".join(["rmmd"] + parts[:-1])
-
-    module = importlib.import_module(module_name)
-    model = getattr(module, class_name)
-
-    assert issubclass(model, BaseModel)
-
-    return model
-
-
 def _load_examples():
     """fills the global variable _examples with the test data from the example
     files
@@ -69,72 +38,21 @@ def _load_examples():
 
     example_files = _list_all_example_files()
 
+
     for file in example_files:
         try:
-            with open(file, "rb") as f:
-                content = yaml.safe_load_all(f)
-                # convert generator to list
-                content = [block for block in content]
+            with open(file, "r", encoding="utf-8") as f:
+                data = yaml.safe_load(f)
 
         except (yaml.YAMLError, OSError) as err:
-            _errors_during_setup.append((file, f"Could not read file: {err}"))
+            _errors_during_setup.append((str(file),
+                                         f"Could not read file: {err}"))
             continue
 
-        match len(content):
-            case 0:
-                _errors_during_setup.append(
-                    (
-                        file,
-                        "File is empty or only contains comments. "
-                        "Expected two blocks: metadata and data.",
-                    )
-                )
-                continue
-            case 1:
-                _errors_during_setup.append(
-                    (
-                        file,
-                        "File contains only one block, expected two: "
-                        "metadata and data.",
-                    )
-                )
-                continue
-            case 2:
-                pass
-            case _:
-                _errors_during_setup.append(
-                    (
-                        file,
-                        "File contains more than two blocks, expected two: "
-                        "metadata and data.",
-                    )
-                )
-
-        try:
-            metadata = ExampleMetadata(
-                **content[0], relative_path=file.relative_to(EXAMPLES_DIR)
-            )
-        except ValidationError as err:
-            _errors_during_setup.append((file, f"Metadata block is invalid: {err}"))
-            continue
-        data = content[1]
-
-        try:
-            model = _import_model(metadata.schema_part)
-        except (ImportError, AttributeError) as err:
-            _errors_during_setup.append(
-                (file, f"Could not import model {metadata.schema_part}: {err}")
-            )
-            continue
-
-        id = f"{metadata.relative_path}"
-
-        _examples["argvalues"].append((data, model, metadata.failures))
-        _examples["ids"].append(id)
-
+        _examples["argvalues"].append(data)
+        _examples["ids"].append(str(file.relative_to(_EXAMPLES_DIR)))
 
 _load_examples()
-
 
 ###############################################################################
 # tests
@@ -151,48 +69,13 @@ def test_test_setup():
         raise RuntimeError(f"Errors during setup:\n{msg}")
 
 
-def _err_loc_str(loc: tuple[str | int, ...]) -> str:
-    """Convert a location tuple to a string"""
-    return ".".join(str(e) for e in loc)
-
-
-@pytest.mark.parametrize("data, schema, expected_errors", **_examples)  # type: ignore
+@pytest.mark.parametrize("data", **_examples)  # type: ignore
 def test_examples(
-    data: dict, schema: BaseModel, expected_errors: list[tuple[str, str]]
+    data: dict
 ):
     """Test that invalid examples raise the expected validation errors"""
-    msg = ""
-    # encountered ids will be removed from this set:
-    unencountered_expected_errids = {i for i in range(len(expected_errors))}
-
-    try:
-        schema.model_validate(data)
-    except ValidationError as val_err:
-        actual_errors = [
-            (_err_loc_str(err["loc"]), err["msg"]) for err in val_err.errors()
-        ]
-        # ids of actual errors that were not expected
-        unexpected_actual_errids = {i for i in range(len(actual_errors))}
-
-        for i_expected, (loc, msg_pattern) in enumerate(expected_errors):
-            for i_actual, actual_err in enumerate(actual_errors):
-                if loc == actual_err[0]:
-                    if re.match(msg_pattern, actual_err[1]):
-                        # expected error was encountered
-                        unencountered_expected_errids.discard(i_expected)
-                        unexpected_actual_errids.discard(i_actual)
-
-        if unexpected_actual_errids:
-            msg += "Unexpected error(s):\n"
-            for i in unexpected_actual_errids:
-                loc, errmsg = actual_errors[i]
-                msg += f"    {loc}: {errmsg}\n"
-
-    if unencountered_expected_errids:
-        msg += "Expected error(s) missing:\n"
-        for i in unencountered_expected_errids:
-            loc, errpattern = expected_errors[i]
-            msg += f"    {loc}: {errpattern}\n"
-
-    if msg:
-        pytest.fail(msg)
+    assert_model_validation_errors(
+        model=schema.Schema,
+        data=data,
+        expected_errors=[],  # no expected errors in the examples
+    )

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -30,6 +30,7 @@ _examples = {  # will be filled later
 _errors_during_setup: list[tuple[str, str]] = []
 """list of files that could not be loaded"""
 
+
 def _load_examples():
     """fills the global variable _examples with the test data from the example
     files
@@ -38,19 +39,18 @@ def _load_examples():
 
     example_files = _list_all_example_files()
 
-
     for file in example_files:
         try:
             with open(file, "r", encoding="utf-8") as f:
                 data = yaml.safe_load(f)
 
         except (yaml.YAMLError, OSError) as err:
-            _errors_during_setup.append((str(file),
-                                         f"Could not read file: {err}"))
+            _errors_during_setup.append((str(file), f"Could not read file: {err}"))
             continue
 
         _examples["argvalues"].append(data)
         _examples["ids"].append(str(file.relative_to(_EXAMPLES_DIR)))
+
 
 _load_examples()
 
@@ -70,9 +70,7 @@ def test_test_setup():
 
 
 @pytest.mark.parametrize("data", **_examples)  # type: ignore
-def test_examples(
-    data: dict
-):
+def test_examples(data: dict):
     """Test that invalid examples raise the expected validation errors"""
     assert_model_validation_errors(
         model=schema.Schema,

--- a/tests/test_rmmd.py
+++ b/tests/test_rmmd.py
@@ -1,0 +1,160 @@
+from pathlib import Path
+from typing import Any
+
+
+from rmmd.test import assert_model_validation_errors
+import yaml
+import pytest
+from pydantic import BaseModel, Field, ValidationError
+
+import importlib
+
+_HERE = Path(__file__).parent.resolve()
+"""directory of this file"""
+_TEST_CASE_DIR = _HERE / "rmmd"
+
+
+class ExampleMetadata(BaseModel):
+    """specification of the metadata block of the test cases"""
+
+    model_config = {"extra": "forbid"}
+
+    failures: list[tuple[tuple[str | int, ...], str]] = Field(default_factory=list)
+    """each item is an expected validation error, given as tuple of a string representing the location of the error and a message."""
+    description: str | None = None
+    schema_part: str = "schema.Schema"  # complete schema by default
+    relative_path: Path
+    """path to the example file relative to the test case directory"""
+
+###############################################################################
+# test case collection
+###############################################################################
+
+
+def _list_test_files():
+    example_files = []
+    for path in _TEST_CASE_DIR.rglob("test_*.yaml"):
+        if path.is_file():
+            example_files.append(path)
+    return example_files
+
+_test_cases = {  # will be filled later
+    "argvalues": [],  # test data + schema
+    "ids": [],  # test names
+}
+
+_errors_during_setup: list[tuple[str, str]] = []
+"""list of files that could not be loaded"""
+
+
+def _import_model(name: str) -> type[BaseModel]:
+    """Get a model by its name"""
+    parts = name.split(".")
+    class_name = parts[-1]
+    module_name = ".".join(["rmmd"] + parts[:-1])
+
+    module = importlib.import_module(module_name)
+    model = getattr(module, class_name)
+
+    assert issubclass(model, BaseModel)
+
+    return model
+
+def _load_test_cases():
+    """fills the global variable _test_cases with the test data from the files
+    in the _TEST_CASE_DIR directory
+    """
+    global _test_cases
+
+    example_files = _list_test_files()
+
+    for file in example_files:
+        try:
+            with open(file, "rb") as f:
+                content = yaml.safe_load_all(f)
+                # convert generator to list
+                content = [block for block in content]
+
+        except (yaml.YAMLError, OSError) as err:
+            _errors_during_setup.append((file, f"Could not read file: {err}"))
+            continue
+
+        match len(content):
+            case 0:
+                _errors_during_setup.append(
+                    (
+                        file,
+                        "File is empty or only contains comments. "
+                        "Expected two blocks: metadata and data.",
+                    )
+                )
+                continue
+            case 1:
+                _errors_during_setup.append(
+                    (
+                        file,
+                        "File contains only one block, expected two: "
+                        "metadata and data.",
+                    )
+                )
+                continue
+            case 2:
+                pass
+            case _:
+                _errors_during_setup.append(
+                    (
+                        file,
+                        "File contains more than two blocks, expected two: "
+                        "metadata and data.",
+                    )
+                )
+
+        try:
+            metadata = ExampleMetadata(
+                **content[0], relative_path=file.relative_to(_TEST_CASE_DIR)
+            )
+        except ValidationError as err:
+            _errors_during_setup.append((file, f"Metadata block is invalid: {err}"))
+            continue
+        data = content[1]
+
+        try:
+            model = _import_model(metadata.schema_part)
+        except (ImportError, AttributeError) as err:
+            _errors_during_setup.append(
+                (file, f"Could not import model {metadata.schema_part}: {err}")
+            )
+            continue
+
+        id = f"{metadata.relative_path}"
+
+        _test_cases["argvalues"].append((data, model, metadata.failures))
+        _test_cases["ids"].append(id)
+
+
+_load_test_cases()
+
+###############################################################################
+# tests
+###############################################################################
+
+def test_test_setup():
+    """Test that the setup was successful and all examples were loaded"""
+
+    if _errors_during_setup:
+        msg = "\n".join(
+            [f"Error loading {file}: {error}" for file, error in _errors_during_setup]
+        )
+        raise RuntimeError(f"Errors during setup:\n{msg}")
+
+
+@pytest.mark.parametrize("data, schema, expected_errors", **_test_cases)  # type: ignore
+def test_model_validation(
+    data: Any, schema: type[BaseModel], expected_errors
+):
+    """Test that invalid examples raise the expected validation errors"""
+    assert_model_validation_errors(
+        model=schema,
+        data=data,
+        expected_errors=expected_errors,
+    )

--- a/tests/test_rmmd.py
+++ b/tests/test_rmmd.py
@@ -26,6 +26,7 @@ class ExampleMetadata(BaseModel):
     relative_path: Path
     """path to the example file relative to the test case directory"""
 
+
 ###############################################################################
 # test case collection
 ###############################################################################
@@ -37,6 +38,7 @@ def _list_test_files():
         if path.is_file():
             example_files.append(path)
     return example_files
+
 
 _test_cases = {  # will be filled later
     "argvalues": [],  # test data + schema
@@ -59,6 +61,7 @@ def _import_model(name: str) -> type[BaseModel]:
     assert issubclass(model, BaseModel)
 
     return model
+
 
 def _load_test_cases():
     """fills the global variable _test_cases with the test data from the files
@@ -138,6 +141,7 @@ _load_test_cases()
 # tests
 ###############################################################################
 
+
 def test_test_setup():
     """Test that the setup was successful and all examples were loaded"""
 
@@ -149,9 +153,7 @@ def test_test_setup():
 
 
 @pytest.mark.parametrize("data, schema, expected_errors", **_test_cases)  # type: ignore
-def test_model_validation(
-    data: Any, schema: type[BaseModel], expected_errors
-):
+def test_model_validation(data: Any, schema: type[BaseModel], expected_errors):
     """Test that invalid examples raise the expected validation errors"""
     assert_model_validation_errors(
         model=schema,

--- a/tests/test_rmmd.py
+++ b/tests/test_rmmd.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from typing import Any
 
 
-from rmmd.test import assert_model_validation_errors
+from rmmd.test import ExpectedError, assert_model_validation_errors
 import yaml
 import pytest
 from pydantic import BaseModel, Field, ValidationError
@@ -19,7 +19,7 @@ class ExampleMetadata(BaseModel):
 
     model_config = {"extra": "forbid"}
 
-    failures: list[tuple[tuple[str | int, ...], str]] = Field(default_factory=list)
+    failures: list[ExpectedError] = Field(default_factory=list)
     """each item is an expected validation error, given as tuple of a string representing the location of the error and a message."""
     description: str | None = None
     schema_part: str = "schema.Schema"  # complete schema by default


### PR DESCRIPTION
examples/ now contains only valid RMMD files whereas tests/ contains yaml files with two blocks: the first block contains data about expected validation errors in the second block.

closes #18 closes #17